### PR TITLE
Optimize to 2- or 3-tuples of rates

### DIFF
--- a/rust/src/lib.rs
+++ b/rust/src/lib.rs
@@ -5,14 +5,45 @@ use std::collections::HashSet;
 use std::iter;
 use test::Bencher;
 
-#[derive(Debug)]
+#[derive(Copy, Clone, Debug)]
 pub struct Rate {
     pub id: u8,
-    pub from: String,
-    pub to: String,
-    pub exchange: String,
     pub rate: f64,
     pub vol: f64,
+    pub from: Currency,
+    pub to: Currency,
+    pub exchange: Exchange,
+}
+
+/// A pair or triple of rates that may form a closed loop
+#[derive(Copy, Clone, Debug)]
+pub struct Arb {
+    a: Rate,
+    b: Rate,
+    c: Option<Rate>,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Eq)]
+pub enum Exchange {
+    D,
+    G,
+    J,
+    Foo,
+}
+
+#[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Eq)]
+pub enum Currency {
+    A,
+    B,
+    C,
+    D,
+    E,
+    F,
+    G,
+    H,
+    I,
+    Y,
+    Z,
 }
 
 impl PartialEq for Rate {
@@ -21,79 +52,106 @@ impl PartialEq for Rate {
     }
 }
 
-pub fn arb_from_rates<'a>(rates: &[&'a Rate], depth: u32) -> Vec<Vec<Vec<&'a Rate>>> {
-    arb_from_combos(combos_from_rates(rates, depth))
+impl PartialEq for Arb {
+    fn eq(&self, other: &Self) -> bool {
+        self.bitset() == other.bitset()
+    }
 }
 
-fn arb_from_combos(mut combos: Vec<Vec<Vec<&Rate>>>) -> Vec<Vec<Vec<&Rate>>> {
-    combos.iter_mut().for_each(|x| {
-        x.retain(|j| is_arb(&j));
-        x.iter_mut().for_each(|x| x.sort_unstable_by_key(|r| r.id));
-        // Relying on the fact that each array will be unique once sorted
-        x.dedup();
-    });
-    combos
+#[derive(PartialEq)]
+struct Bitset {
+    arr: [u64; 4],
 }
 
-fn is_arb(list: &[&Rate]) -> bool {
-    if list.len() < 2 {
-        return false;
+impl Bitset {
+    pub const fn empty() -> Self {
+        Bitset { arr: [0u64; 4] }
     }
 
-    if list[0].from != list[list.len() - 1].to {
-        return false;
+    fn set(&mut self, val: u8) {
+        let idx = val / 64;
+        let shift = val % 64;
+        self.arr[idx as usize] |= (1 << shift);
     }
 
-    list.windows(2)
-        .try_fold(list[0].rate, |prod, rates| {
-            if rates[0].to != rates[1].from {
-                return None;
-            }
-            Some(prod * rates[1].rate)
-        })
-        .map_or(false, |prod| prod > 1.0)
+    fn test(&mut self, val: u8) -> bool {
+        let idx = val / 64;
+        let shift = val % 64;
+        (self.arr[idx as usize] & (1 << shift)) != 0
+    }
 }
 
-fn combos_from_rates<'a>(rates: &[&'a Rate], depth: u32) -> Vec<Vec<Vec<&'a Rate>>> {
-    let mut ret = Vec::with_capacity(depth as usize + 1);
-    ret.push(build_base(rates));
+impl Arb {
+    fn is_closed(&self) -> bool {
+        if self.a.from == self.b.to {
+            return true;
+        }
+        if let Some(third) = self.c {
+            return self.a.from == third.to;
+        }
+        false
+    }
 
-    for i in 1..(depth as usize) {
-        let mut tmp = Vec::new();
-        for j in 0..ret[i - 1].len() {
-            for k in 0..rates.len() {
-                if ret[i - 1][j].last().unwrap().to == rates[k].from
-                    && !is_rate_in_list(&ret[i - 1][j], rates[k])
-                    && !is_list_closing(&ret[i - 1][j])
-                {
-                    tmp.push(
-                        ret[i - 1][j]
-                            .iter()
-                            .chain(iter::once(&rates[k]))
-                            .copied()
-                            .collect(),
-                    );
+    fn contains(&self, rate: Rate) -> bool {
+        let c = match self.c {
+            Some(r) => r == rate,
+            _ => false,
+        };
+        self.a == rate || self.b == rate || c
+    }
+
+    fn is_arb(&self) -> bool {
+        if !self.is_closed() {
+            return false;
+        }
+
+        self.a.rate * self.b.rate * self.c.map(|o| o.rate).unwrap_or(1.0) > 1.0
+    }
+
+    fn bitset(&self) -> Bitset {
+        let mut bs = Bitset::empty();
+        bs.set(self.a.id);
+        bs.set(self.b.id);
+        bs.set(self.c.map(|c| c.id).unwrap_or(0));
+        bs
+    }
+}
+
+pub fn arb_from_rates<'a>(rates: &[&'a Rate]) -> Vec<Arb> {
+    let base = build_base(rates);
+    let mut out = Vec::with_capacity(base.len() * 10);
+    for b in base {
+        if b.is_closed() {
+            out.push(b);
+            continue;
+        }
+        for &i in rates {
+            if !b.contains(*i) && b.b.to == i.from && i.to == b.a.from {
+                let mut closed = b;
+                closed.c = Some(*i);
+                if closed.is_arb() {
+                    out.push(closed);
                 }
             }
         }
-        ret.push(tmp);
     }
-
-    ret
+    out.dedup();
+    out
 }
 
-fn is_list_closing(list: &Vec<&Rate>) -> bool {
-    list[0].from == list.last().unwrap().to
-}
-
-fn build_base<'a>(rates: &[&'a Rate]) -> Vec<Vec<&'a Rate>> {
+#[inline]
+fn build_base<'a>(rates: &[&'a Rate]) -> Vec<Arb> {
     rates
         .iter()
         .enumerate()
         .flat_map(|(i, &rate_a)| {
             rates[(i + 1)..].iter().filter_map(move |&rate_b| {
                 if rate_a.to == rate_b.from {
-                    Some(vec![rate_a, rate_b])
+                    Some(Arb {
+                        a: *rate_a,
+                        b: *rate_b,
+                        c: None,
+                    })
                 } else {
                     None
                 }
@@ -102,257 +160,233 @@ fn build_base<'a>(rates: &[&'a Rate]) -> Vec<Vec<&'a Rate>> {
         .collect()
 }
 
-fn is_rate_in_list(list: &[&Rate], r: &Rate) -> bool {
-    list.iter().any(|&rate| rate == r)
-}
-
-fn is_dupe<'a>(list: &'a Vec<Vec<&'a Rate>>, arb: &'a Vec<&'a Rate>) -> bool {
-    if list.len() == 0 {
-        return false
+#[inline]
+pub fn v_to_rc(mut v: Vec<Rate>) -> Arb {
+    Arb {
+        a: v.remove(0),
+        b: v.remove(0),
+        c: v.pop(),
     }
-
-    let mut m: HashSet<u8> = HashSet::new();
-
-    for i in 0..arb.len() {
-        m.insert(
-            arb[i].id,
-        );
-    }
-
-    for i in 0..list.len() {
-        let mut count = 0;
-        for j in 0..list[i].len() {
-            if m.contains(&list[i][j].id) {
-                count = count + 1;
-            }
-        }
-
-        if count == list[i].len() {
-            return true
-        }
-    }
-
-    return false
 }
 
 fn main() {
-    let r1 = &Rate{
+    let r1 = &Rate {
         id: 0,
-        from: String::from("a"),
-        to: String::from("b"),
-        exchange: String::from("j"),
+        from: Currency::A,
+        to: Currency::B,
+        exchange: Exchange::J,
         rate: 2.0,
         vol: 1.0,
     };
-    let r2 = &Rate{
+    let r2 = &Rate {
         id: 2,
-        from: String::from("a"),
-        to: String::from("c"),
-        exchange: String::from("j"),
+        from: Currency::A,
+        to: Currency::C,
+        exchange: Exchange::J,
         rate: 2.0,
         vol: 1.0,
     };
-    let r3 = &Rate{
+    let r3 = &Rate {
         id: 3,
-        from: String::from("a"),
-        to: String::from("d"),
-        exchange: String::from("j"),
+        from: Currency::A,
+        to: Currency::D,
+        exchange: Exchange::J,
         rate: 2.0,
         vol: 1.0,
     };
-    let r4 = &Rate{
+    let r4 = &Rate {
         id: 4,
-        from: String::from("a"),
-        to: String::from("e"),
-        exchange: String::from("j"),
+        from: Currency::A,
+        to: Currency::E,
+        exchange: Exchange::J,
         rate: 2.0,
         vol: 1.0,
     };
-    let r5 = &Rate{
+    let r5 = &Rate {
         id: 5,
-        from: String::from("b"),
-        to: String::from("a"),
-        exchange: String::from("j"),
+        from: Currency::B,
+        to: Currency::A,
+        exchange: Exchange::J,
         rate: 2.0,
         vol: 1.0,
     };
-    let r6 = &Rate{
+    let r6 = &Rate {
         id: 6,
-        from: String::from("b"),
-        to: String::from("c"),
-        exchange: String::from("j"),
+        from: Currency::B,
+        to: Currency::C,
+        exchange: Exchange::J,
         rate: 2.0,
         vol: 1.0,
     };
-    let r7 = &Rate{
+    let r7 = &Rate {
         id: 7,
-        from: String::from("b"),
-        to: String::from("d"),
-        exchange: String::from("j"),
+        from: Currency::B,
+        to: Currency::D,
+        exchange: Exchange::J,
         rate: 2.0,
         vol: 1.0,
     };
-    let r8 = &Rate{
+    let r8 = &Rate {
         id: 8,
-        from: String::from("b"),
-        to: String::from("e"),
-        exchange: String::from("j"),
+        from: Currency::B,
+        to: Currency::E,
+        exchange: Exchange::J,
         rate: 2.0,
         vol: 1.0,
     };
-    let r9 = &Rate{
+    let r9 = &Rate {
         id: 9,
-        from: String::from("c"),
-        to: String::from("a"),
-        exchange: String::from("j"),
+        from: Currency::C,
+        to: Currency::A,
+        exchange: Exchange::J,
         rate: 2.0,
         vol: 1.0,
     };
-    let r10 = &Rate{
+    let r10 = &Rate {
         id: 10,
-        from: String::from("c"),
-        to: String::from("b"),
-        exchange: String::from("j"),
+        from: Currency::C,
+        to: Currency::B,
+        exchange: Exchange::J,
         rate: 2.0,
         vol: 1.0,
     };
-    let r11 = &Rate{
+    let r11 = &Rate {
         id: 11,
-        from: String::from("c"),
-        to: String::from("d"),
-        exchange: String::from("j"),
+        from: Currency::C,
+        to: Currency::D,
+        exchange: Exchange::J,
         rate: 2.0,
         vol: 1.0,
     };
-    let r12 = &Rate{
+    let r12 = &Rate {
         id: 12,
-        from: String::from("c"),
-        to: String::from("e"),
-        exchange: String::from("j"),
+        from: Currency::C,
+        to: Currency::E,
+        exchange: Exchange::J,
         rate: 2.0,
         vol: 1.0,
     };
-    let r13 = &Rate{
+    let r13 = &Rate {
         id: 13,
-        from: String::from("d"),
-        to: String::from("a"),
-        exchange: String::from("j"),
+        from: Currency::D,
+        to: Currency::A,
+        exchange: Exchange::J,
         rate: 2.0,
         vol: 1.0,
     };
-    let r14 = &Rate{
+    let r14 = &Rate {
         id: 14,
-        from: String::from("d"),
-        to: String::from("b"),
-        exchange: String::from("j"),
+        from: Currency::D,
+        to: Currency::B,
+        exchange: Exchange::J,
         rate: 2.0,
         vol: 1.0,
     };
-    let r15 = &Rate{
+    let r15 = &Rate {
         id: 15,
-        from: String::from("d"),
-        to: String::from("c"),
-        exchange: String::from("j"),
+        from: Currency::D,
+        to: Currency::C,
+        exchange: Exchange::J,
         rate: 2.0,
         vol: 1.0,
     };
-    let r16 = &Rate{
+    let r16 = &Rate {
         id: 16,
-        from: String::from("d"),
-        to: String::from("e"),
-        exchange: String::from("j"),
+        from: Currency::D,
+        to: Currency::E,
+        exchange: Exchange::J,
         rate: 2.0,
         vol: 1.0,
     };
-    let r17 = &Rate{
+    let r17 = &Rate {
         id: 17,
-        from: String::from("e"),
-        to: String::from("a"),
-        exchange: String::from("j"),
+        from: Currency::E,
+        to: Currency::A,
+        exchange: Exchange::J,
         rate: 2.0,
         vol: 1.0,
     };
-    let r18 = &Rate{
+    let r18 = &Rate {
         id: 18,
-        from: String::from("e"),
-        to: String::from("b"),
-        exchange: String::from("j"),
+        from: Currency::E,
+        to: Currency::B,
+        exchange: Exchange::J,
         rate: 2.0,
         vol: 1.0,
     };
-    let r19 = &Rate{
+    let r19 = &Rate {
         id: 19,
-        from: String::from("e"),
-        to: String::from("c"),
-        exchange: String::from("j"),
+        from: Currency::E,
+        to: Currency::C,
+        exchange: Exchange::J,
         rate: 2.0,
         vol: 1.0,
     };
-    let r20 = &Rate{
+    let r20 = &Rate {
         id: 20,
-        from: String::from("e"),
-        to: String::from("d"),
-        exchange: String::from("j"),
+        from: Currency::E,
+        to: Currency::D,
+        exchange: Exchange::J,
         rate: 2.0,
         vol: 1.0,
     };
-    let l = vec![r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15, r16, r17, r18, r19, r20];
+    let l = vec![
+        r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15, r16, r17, r18, r19, r20,
+    ];
 
-    //let mut tmp: Vec<Vec<Vec<&Rate>>> = Vec::new();
     for _ in 0..100 {
-        arb_from_rates(&l, 5);
+        arb_from_rates(&l);
     }
-    //println!("tmp len: {}", tmp.len());
 }
 
 #[test]
 fn test_is_rate_in_list() {
     let r1 = Rate {
         id: 0,
-        from: String::from("a"),
-        to: String::from("b"),
-        exchange: String::from("d"),
+        from: Currency::A,
+        to: Currency::B,
+        exchange: Exchange::D,
         rate: 1.0,
         vol: 1.0,
     };
     let r2 = Rate {
         id: 1,
-        from: String::from("e"),
-        to: String::from("f"),
-        exchange: String::from("g"),
+        from: Currency::E,
+        to: Currency::F,
+        exchange: Exchange::G,
         rate: 1.0,
         vol: 1.0,
     };
     let r3 = Rate {
         id: 2,
-        from: String::from("h"),
-        to: String::from("i"),
-        exchange: String::from("j"),
+        from: Currency::H,
+        to: Currency::I,
+        exchange: Exchange::J,
         rate: 1.0,
         vol: 1.0,
     };
-    let l1 = vec![&r1, &r2, &r3];
-    let l2 = vec![&r2, &r3];
+    let l1 = v_to_rc(vec![r1, r2, r3]);
+    let l2 = v_to_rc(vec![r2, r3]);
 
-    assert_eq!(is_rate_in_list(&l1, &r1), true);
-    assert_eq!(is_rate_in_list(&l2, &r1), false);
+    assert_eq!(l1.contains(r1), true);
+    assert_eq!(l2.contains(r1), false);
 }
 
 #[test]
 fn test_build_base() {
-    let r1 = Rate{
+    let r1 = Rate {
         id: 0,
-        from: String::from("a"),
-        to: String::from("b"),
-        exchange: String::from("j"),
+        from: Currency::A,
+        to: Currency::B,
+        exchange: Exchange::J,
         rate: 1.0,
         vol: 1.0,
     };
-    let r2 = Rate{
+    let r2 = Rate {
         id: 1,
-        from: String::from("b"),
-        to:   String::from("a"),
-        exchange: String::from("foo"),
+        from: Currency::B,
+        to: Currency::A,
+        exchange: Exchange::Foo,
         rate: 1.0,
         vol: 1.0,
     };
@@ -364,442 +398,423 @@ fn test_build_base() {
 
 #[test]
 fn test_is_list_closing() {
-    let r1 = Rate{
+    let r1 = Rate {
         id: 0,
-        from: String::from("a"),
-        to: String::from("b"),
-        exchange: String::from("j"),
+        from: Currency::A,
+        to: Currency::B,
+        exchange: Exchange::J,
         rate: 1.0,
         vol: 1.0,
     };
-    let r2 = Rate{
+    let r2 = Rate {
         id: 1,
-        from: String::from("b"),
-        to:   String::from("a"),
-        exchange: String::from("foo"),
+        from: Currency::B,
+        to: Currency::A,
+        exchange: Exchange::Foo,
         rate: 1.0,
         vol: 1.0,
     };
-    let r3 = Rate{
+    let r3 = Rate {
         id: 2,
-        from: String::from("b"),
-        to:   String::from("c"),
-        exchange: String::from("foo"),
+        from: Currency::B,
+        to: Currency::C,
+        exchange: Exchange::Foo,
         rate: 1.0,
         vol: 1.0,
     };
-    let l1 = vec![&r1, &r2];
-    let l2 = vec![&r1, &r3];
+    let l1 = v_to_rc(vec![r1, r2]);
+    let l2 = v_to_rc(vec![r1, r3]);
 
-    assert_eq!(is_list_closing(&l1), true);
-    assert_eq!(is_list_closing(&l2), false);
+    assert_eq!(l1.is_closed(), true);
+    assert_eq!(l2.is_closed(), false);
 }
 
 #[test]
 fn test_combos_from_rates() {
-    let r1 = Rate{
+    let r1 = Rate {
         id: 0,
-        from: String::from("a"),
-        to: String::from("b"),
-        exchange: String::from("j"),
+        from: Currency::A,
+        to: Currency::B,
+        exchange: Exchange::J,
         rate: 1.0,
         vol: 1.0,
     };
-    let r2 = Rate{
+    let r2 = Rate {
         id: 1,
-        from: String::from("b"),
-        to: String::from("c"),
-        exchange: String::from("j"),
+        from: Currency::B,
+        to: Currency::C,
+        exchange: Exchange::J,
         rate: 1.0,
         vol: 1.0,
     };
-    let r3 = Rate{
+    let r3 = Rate {
         id: 2,
-        from: String::from("c"),
-        to: String::from("d"),
-        exchange: String::from("j"),
+        from: Currency::C,
+        to: Currency::D,
+        exchange: Exchange::J,
         rate: 1.0,
         vol: 1.0,
     };
-    let r4 = Rate{
+    let r4 = Rate {
         id: 3,
-        from: String::from("y"),
-        to: String::from("z"),
-        exchange: String::from("j"),
+        from: Currency::Y,
+        to: Currency::Z,
+        exchange: Exchange::J,
         rate: 1.0,
         vol: 1.0,
     };
 
     let l1 = vec![&r1, &r2, &r3, &r4];
-    let c1 = combos_from_rates(&l1, 4);
+    let c1 = arb_from_rates(&l1);
 
-    assert_eq!(c1.len(), 4);
-    assert_eq!(c1[0].len(), 2);
-    assert_eq!(c1[0][0].len(), 2);
-    assert_eq!(c1[0][1].len(), 2);
-    assert_eq!(c1[1].len(), 1);
-    assert_eq!(c1[1][0].len(), 3);
+    assert_eq!(c1.len(), 0);
 }
 
 #[test]
 fn test_is_arb() {
-    assert_eq!(is_arb(&vec![&Rate{
-        id: 0,
-        from: String::from("y"),
-        to: String::from("z"),
-        exchange: String::from("j"),
-        rate: 1.0,
-        vol: 1.0,
-    }]), false);
+    assert_eq!(
+        v_to_rc(vec![
+            Rate {
+                id: 0,
+                from: Currency::A,
+                to: Currency::B,
+                exchange: Exchange::J,
+                rate: 1.0,
+                vol: 1.0,
+            },
+            Rate {
+                id: 1,
+                from: Currency::B,
+                to: Currency::A,
+                exchange: Exchange::J,
+                rate: 1.0,
+                vol: 1.0,
+            }
+        ])
+        .is_arb(),
+        false
+    );
 
-    assert_eq!(is_arb(&vec![&Rate{
-        id: 0,
-        from: String::from("a"),
-        to: String::from("b"),
-        exchange: String::from("j"),
-        rate: 1.0,
-        vol: 1.0,
-    }, &Rate{
-        id: 1,
-        from: String::from("b"),
-        to: String::from("a"),
-        exchange: String::from("j"),
-        rate: 1.0,
-        vol: 1.0,
-    }]), false);
+    assert_eq!(
+        v_to_rc(vec![
+            Rate {
+                id: 0,
+                from: Currency::Y,
+                to: Currency::Z,
+                exchange: Exchange::J,
+                rate: 1.0,
+                vol: 1.0,
+            },
+            Rate {
+                id: 1,
+                from: Currency::A,
+                to: Currency::B,
+                exchange: Exchange::J,
+                rate: 1.0,
+                vol: 1.0,
+            }
+        ])
+        .is_arb(),
+        false
+    );
 
-    assert_eq!(is_arb(&vec![&Rate{
-        id: 0,
-        from: String::from("y"),
-        to: String::from("z"),
-        exchange: String::from("j"),
-        rate: 1.0,
-        vol: 1.0,
-    }, &Rate{
-        id: 1,
-        from: String::from("a"),
-        to: String::from("b"),
-        exchange: String::from("j"),
-        rate: 1.0,
-        vol: 1.0,
-    }]), false);
+    assert_eq!(
+        v_to_rc(vec![
+            Rate {
+                id: 0,
+                from: Currency::A,
+                to: Currency::B,
+                exchange: Exchange::J,
+                rate: 2.0,
+                vol: 1.0,
+            },
+            Rate {
+                id: 1,
+                from: Currency::B,
+                to: Currency::C,
+                exchange: Exchange::J,
+                rate: 2.0,
+                vol: 1.0,
+            }
+        ])
+        .is_arb(),
+        false
+    );
 
-    assert_eq!(is_arb(&vec![&Rate{
-        id: 0,
-        from: String::from("a"),
-        to: String::from("b"),
-        exchange: String::from("j"),
-        rate: 2.0,
-        vol: 1.0,
-    }, &Rate{
-        id: 1,
-        from: String::from("b"),
-        to: String::from("c"),
-        exchange: String::from("j"),
-        rate: 2.0,
-        vol: 1.0,
-    }]), false);
+    assert_eq!(
+        v_to_rc(vec![
+            Rate {
+                id: 0,
+                from: Currency::A,
+                to: Currency::B,
+                exchange: Exchange::J,
+                rate: 2.0,
+                vol: 1.0,
+            },
+            Rate {
+                id: 1,
+                from: Currency::B,
+                to: Currency::C,
+                exchange: Exchange::J,
+                rate: 2.0,
+                vol: 1.0,
+            },
+            Rate {
+                id: 2,
+                from: Currency::C,
+                to: Currency::A,
+                exchange: Exchange::J,
+                rate: 2.0,
+                vol: 1.0,
+            }
+        ])
+        .is_arb(),
+        true
+    );
 
-    assert_eq!(is_arb(&vec![&Rate{
-        id: 0,
-        from: String::from("a"),
-        to: String::from("b"),
-        exchange: String::from("j"),
-        rate: 2.0,
-        vol: 1.0,
-    }, &Rate{
-        id: 1,
-        from: String::from("b"),
-        to: String::from("c"),
-        exchange: String::from("j"),
-        rate: 2.0,
-        vol: 1.0,
-    }, &Rate{
-        id: 2,
-        from: String::from("c"),
-        to: String::from("a"),
-        exchange: String::from("j"),
-        rate: 2.0,
-        vol: 1.0,
-    }]), true);
-
-    assert_eq!(is_arb(&vec![&Rate{
-        id: 0,
-        from: String::from("a"),
-        to: String::from("b"),
-        exchange: String::from("j"),
-        rate: 1.0,
-        vol: 1.0,
-    }, &Rate{
-        id: 1,
-        from: String::from("b"),
-        to: String::from("c"),
-        exchange: String::from("j"),
-        rate: 1.0,
-        vol: 1.0,
-    }, &Rate{
-        id: 2,
-        from: String::from("c"),
-        to: String::from("a"),
-        exchange: String::from("j"),
-        rate: 1.0,
-        vol: 1.0,
-    }]), false);
-}
-
-#[test]
-fn test_is_dupe() {
-    let r1 = Rate{
-        id: 0,
-        from: String::from("a"),
-        to: String::from("b"),
-        exchange: String::from("j"),
-        rate: 1.0,
-        vol: 1.0,
-    };
-    let r2 = Rate{
-        id: 1,
-        from: String::from("b"),
-        to: String::from("c"),
-        exchange: String::from("j"),
-        rate: 1.0,
-        vol: 1.0,
-    };
-    let r3 = Rate{
-        id: 2,
-        from: String::from("c"),
-        to: String::from("d"),
-        exchange: String::from("j"),
-        rate: 1.0,
-        vol: 1.0,
-    };
-    let r4 = Rate{
-        id: 3,
-        from: String::from("y"),
-        to: String::from("z"),
-        exchange: String::from("j"),
-        rate: 1.0,
-        vol: 1.0,
-    };
-
-    assert_eq!(is_dupe(&vec![vec![&r1, &r2, &r3], vec![&r4, &r4, &r4]], &vec![&r1, &r2, &r3]), true);
-    assert_eq!(is_dupe(&vec![vec![&r4, &r4, &r4], vec![&r4, &r4, &r4]], &vec![&r1, &r2, &r3]), false);
+    assert_eq!(
+        v_to_rc(vec![
+            Rate {
+                id: 0,
+                from: Currency::A,
+                to: Currency::B,
+                exchange: Exchange::J,
+                rate: 1.0,
+                vol: 1.0,
+            },
+            Rate {
+                id: 1,
+                from: Currency::B,
+                to: Currency::C,
+                exchange: Exchange::J,
+                rate: 1.0,
+                vol: 1.0,
+            },
+            Rate {
+                id: 2,
+                from: Currency::C,
+                to: Currency::A,
+                exchange: Exchange::J,
+                rate: 1.0,
+                vol: 1.0,
+            }
+        ])
+        .is_arb(),
+        false
+    );
 }
 
 #[test]
 fn test_arb_from_rates() {
-    let r1 = Rate{
+    let r1 = Rate {
         id: 0,
-        from: String::from("a"),
-        to: String::from("b"),
-        exchange: String::from("j"),
+        from: Currency::A,
+        to: Currency::B,
+        exchange: Exchange::J,
         rate: 2.0,
         vol: 1.0,
     };
-    let r2 = Rate{
+    let r2 = Rate {
         id: 1,
-        from: String::from("b"),
-        to: String::from("c"),
-        exchange: String::from("j"),
+        from: Currency::B,
+        to: Currency::C,
+        exchange: Exchange::J,
         rate: 2.0,
         vol: 1.0,
     };
-    let r3 = Rate{
+    let r3 = Rate {
         id: 3,
-        from: String::from("c"),
-        to: String::from("a"),
-        exchange: String::from("j"),
+        from: Currency::C,
+        to: Currency::A,
+        exchange: Exchange::J,
         rate: 2.0,
         vol: 1.0,
     };
-    let r4 = Rate{
+    let r4 = Rate {
         id: 4,
-        from: String::from("y"),
-        to: String::from("z"),
-        exchange: String::from("j"),
+        from: Currency::Y,
+        to: Currency::Z,
+        exchange: Exchange::J,
         rate: 2.0,
         vol: 1.0,
     };
-    
+
     let l1 = vec![&r1, &r2, &r3, &r4];
-    let arb = arb_from_rates(&l1, 4);
-    assert_eq!(arb.len(), 4);
-    assert_eq!(arb[0].len(), 0);
-    assert_eq!(arb[1].len(), 1);
-    assert_eq!(arb[1][0].len(), 3);
-    assert_eq!(arb[2].len(), 0);
-    assert_eq!(arb[3].len(), 0);
+    let arb = arb_from_rates(&l1);
+    assert_eq!(arb, vec![v_to_rc(vec![r1, r2, r3])]);
 }
 
 #[bench]
 fn bench_arb(b: &mut Bencher) {
-    let r1 = &Rate{
+    let r1 = &Rate {
         id: 0,
-        from: String::from("a"),
-        to: String::from("b"),
-        exchange: String::from("j"),
+        from: Currency::A,
+        to: Currency::B,
+        exchange: Exchange::J,
         rate: 2.0,
         vol: 1.0,
     };
-    let r2 = &Rate{
+    let r2 = &Rate {
         id: 2,
-        from: String::from("a"),
-        to: String::from("c"),
-        exchange: String::from("j"),
+        from: Currency::A,
+        to: Currency::C,
+        exchange: Exchange::J,
         rate: 2.0,
         vol: 1.0,
     };
-    let r3 = &Rate{
+    let r3 = &Rate {
         id: 3,
-        from: String::from("a"),
-        to: String::from("d"),
-        exchange: String::from("j"),
+        from: Currency::A,
+        to: Currency::D,
+        exchange: Exchange::J,
         rate: 2.0,
         vol: 1.0,
     };
-    let r4 = &Rate{
+    let r4 = &Rate {
         id: 4,
-        from: String::from("a"),
-        to: String::from("e"),
-        exchange: String::from("j"),
+        from: Currency::A,
+        to: Currency::E,
+        exchange: Exchange::J,
         rate: 2.0,
         vol: 1.0,
     };
-    let r5 = &Rate{
+    let r5 = &Rate {
         id: 5,
-        from: String::from("b"),
-        to: String::from("a"),
-        exchange: String::from("j"),
+        from: Currency::B,
+        to: Currency::A,
+        exchange: Exchange::J,
         rate: 2.0,
         vol: 1.0,
     };
-    let r6 = &Rate{
+    let r6 = &Rate {
         id: 6,
-        from: String::from("b"),
-        to: String::from("c"),
-        exchange: String::from("j"),
+        from: Currency::B,
+        to: Currency::C,
+        exchange: Exchange::J,
         rate: 2.0,
         vol: 1.0,
     };
-    let r7 = &Rate{
+    let r7 = &Rate {
         id: 7,
-        from: String::from("b"),
-        to: String::from("d"),
-        exchange: String::from("j"),
+        from: Currency::B,
+        to: Currency::D,
+        exchange: Exchange::J,
         rate: 2.0,
         vol: 1.0,
     };
-    let r8 = &Rate{
+    let r8 = &Rate {
         id: 8,
-        from: String::from("b"),
-        to: String::from("e"),
-        exchange: String::from("j"),
+        from: Currency::B,
+        to: Currency::E,
+        exchange: Exchange::J,
         rate: 2.0,
         vol: 1.0,
     };
-    let r9 = &Rate{
+    let r9 = &Rate {
         id: 9,
-        from: String::from("c"),
-        to: String::from("a"),
-        exchange: String::from("j"),
+        from: Currency::C,
+        to: Currency::A,
+        exchange: Exchange::J,
         rate: 2.0,
         vol: 1.0,
     };
-    let r10 = &Rate{
+    let r10 = &Rate {
         id: 10,
-        from: String::from("c"),
-        to: String::from("b"),
-        exchange: String::from("j"),
+        from: Currency::C,
+        to: Currency::B,
+        exchange: Exchange::J,
         rate: 2.0,
         vol: 1.0,
     };
-    let r11 = &Rate{
+    let r11 = &Rate {
         id: 11,
-        from: String::from("c"),
-        to: String::from("d"),
-        exchange: String::from("j"),
+        from: Currency::C,
+        to: Currency::D,
+        exchange: Exchange::J,
         rate: 2.0,
         vol: 1.0,
     };
-    let r12 = &Rate{
+    let r12 = &Rate {
         id: 12,
-        from: String::from("c"),
-        to: String::from("e"),
-        exchange: String::from("j"),
+        from: Currency::C,
+        to: Currency::E,
+        exchange: Exchange::J,
         rate: 2.0,
         vol: 1.0,
     };
-    let r13 = &Rate{
+    let r13 = &Rate {
         id: 13,
-        from: String::from("d"),
-        to: String::from("a"),
-        exchange: String::from("j"),
+        from: Currency::D,
+        to: Currency::A,
+        exchange: Exchange::J,
         rate: 2.0,
         vol: 1.0,
     };
-    let r14 = &Rate{
+    let r14 = &Rate {
         id: 14,
-        from: String::from("d"),
-        to: String::from("b"),
-        exchange: String::from("j"),
+        from: Currency::D,
+        to: Currency::B,
+        exchange: Exchange::J,
         rate: 2.0,
         vol: 1.0,
     };
-    let r15 = &Rate{
+    let r15 = &Rate {
         id: 15,
-        from: String::from("d"),
-        to: String::from("c"),
-        exchange: String::from("j"),
+        from: Currency::D,
+        to: Currency::C,
+        exchange: Exchange::J,
         rate: 2.0,
         vol: 1.0,
     };
-    let r16 = &Rate{
+    let r16 = &Rate {
         id: 16,
-        from: String::from("d"),
-        to: String::from("e"),
-        exchange: String::from("j"),
+        from: Currency::D,
+        to: Currency::E,
+        exchange: Exchange::J,
         rate: 2.0,
         vol: 1.0,
     };
-    let r17 = &Rate{
+    let r17 = &Rate {
         id: 17,
-        from: String::from("e"),
-        to: String::from("a"),
-        exchange: String::from("j"),
+        from: Currency::E,
+        to: Currency::A,
+        exchange: Exchange::J,
         rate: 2.0,
         vol: 1.0,
     };
-    let r18 = &Rate{
+    let r18 = &Rate {
         id: 18,
-        from: String::from("e"),
-        to: String::from("b"),
-        exchange: String::from("j"),
+        from: Currency::E,
+        to: Currency::B,
+        exchange: Exchange::J,
         rate: 2.0,
         vol: 1.0,
     };
-    let r19 = &Rate{
+    let r19 = &Rate {
         id: 19,
-        from: String::from("e"),
-        to: String::from("c"),
-        exchange: String::from("j"),
+        from: Currency::E,
+        to: Currency::C,
+        exchange: Exchange::J,
         rate: 2.0,
         vol: 1.0,
     };
-    let r20 = &Rate{
+    let r20 = &Rate {
         id: 20,
-        from: String::from("e"),
-        to: String::from("d"),
-        exchange: String::from("j"),
+        from: Currency::E,
+        to: Currency::D,
+        exchange: Exchange::J,
         rate: 2.0,
         vol: 1.0,
     };
-    let l = vec![r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15, r16, r17, r18, r19, r20];
+    let l = vec![
+        r1, r2, r3, r4, r5, r6, r7, r8, r9, r10, r11, r12, r13, r14, r15, r16, r17, r18, r19, r20,
+    ];
 
     // note: don't want rust to optimize away by not using output
     //let mut tmp: Vec<Vec<Vec<&Rate>>> = Vec::new();
     b.iter(|| {
         //tmp = arb_from_rates(&l, 5);
-        arb_from_rates(&l, 5);
+        arb_from_rates(&l);
     });
     //println!("tmp len: {}", tmp.len());
 }


### PR DESCRIPTION
I've aggressively optimized for cases of pairs or triples of rates that form a closed loop. This might not be exactly what you want in practice, but it provides a 99.4% speed up from the original code (assuming that I haven't silently introduced some logic bug). You could certainly extend this to some known N-tuple size (presumably there is a limit to how many trades you want to make to get your arbitrage, anyway)

Original benchmark: 485,486 ns/iter

After optimization: 3,880 ns/iter